### PR TITLE
fix: safely call paintExtentOf

### DIFF
--- a/lib/src/rendering/sliver_waterfall_flow.dart
+++ b/lib/src/rendering/sliver_waterfall_flow.dart
@@ -443,7 +443,7 @@ class RenderSliverWaterfallFlow extends RenderSliverMultiBoxAdaptor
         child = childAfter(child);
       }
       final int? minLeadingIndex = crossAxisChildrenData.minLeadingIndex;
-      while (child != null && minLeadingIndex! < indexOf(child)) {
+      while (child != null && child.hasSize && minLeadingIndex! < indexOf(child)) {
         crossAxisChildrenData.insertLeading(
             child: child, paintExtentOf: paintExtentOf);
         child = childBefore(child);


### PR DESCRIPTION
在 `insertLeading` 方法中会调用传入的 `paintExtentOf` 方法获取 `child` 的绘制大小，但没有在调用前对 `child.hasSize` 进行判断，导致有时会出现瀑布流白屏的异常现象，进而无法继续正常使用。

https://github.com/fluttercandies/waterfall_flow/blob/21bd3598cd946655bf96f886b98710c0b1b11759/lib/src/rendering/sliver_waterfall_flow.dart#L445-L450



<img width="1367" alt="image" src="https://github.com/user-attachments/assets/8ddf6c6a-fd52-430c-8908-77eadf1af2b4">


该 `PR` 添加 `child.hasSize` 来安全调用 `paintExtentOf` 从而避免瀑布流白屏问题。

希望能尽快发布修复版本 ☕
