### PR TITLE
Changed IndexedWidgetBuilder to NullableIndexedWidgetBuilder

### DIFF
--- a/lib/src/widgets/scroll_view.dart
+++ b/lib/src/widgets/scroll_view.dart
@@ -289,7 +289,7 @@ class WaterfallFlow extends BoxScrollView {
     bool shrinkWrap = false,
     EdgeInsetsGeometry? padding,
     required this.gridDelegate,
-    required IndexedWidgetBuilder itemBuilder,
+    required NullableIndexedWidgetBuilder itemBuilder,
     int? itemCount,
     bool addAutomaticKeepAlives = true,
     bool addRepaintBoundaries = true,
@@ -328,7 +328,7 @@ class WaterfallFlow extends BoxScrollView {
   /// Creates a scrollable, 2D array of widgets whose size is variable in the main axis
   /// with both a custom [SliverGridDelegate] and a custom [SliverChildDelegate].
   ///
-  /// To use an [IndexedWidgetBuilder] callback to build children, either use
+  /// To use an [NullableIndexedWidgetBuilder] callback to build children, either use
   /// a [SliverChildBuilderDelegate] or use the [WaterfallFlow.builder] constructor.
   ///
   /// The [gridDelegate] and [childrenDelegate] arguments must not be null.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.3
 homepage: https://github.com/fluttercandies/waterfall_flow
 
 environment:
-  sdk: '>=2.19.0 <4.0.0'
-  flutter: ">=3.7.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=2.0.0"
 dependencies:
   collection: ^1.15.0
   extended_list_library: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ version: 3.0.3
 homepage: https://github.com/fluttercandies/waterfall_flow
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=2.0.0"
+  sdk: '>=2.19.0 <4.0.0'
+  flutter: ">=3.7.0"
 dependencies:
   collection: ^1.15.0
   extended_list_library: ^3.0.0


### PR DESCRIPTION
* This change allows itemBuilder to return null in some cases

example:
```dart
WaterfallFlow.builder(
  gridDelegate: const SliverWaterfallFlowDelegateWithMaxCrossAxisExtent(
    maxCrossAxisExtent: 256,
  ),
  itemBuilder: (context, index) {
    // now we can return null
    if (index >= 10) return null;
    return AspectRatio(aspectRatio: 1.5);
  },
)
```